### PR TITLE
action: use checksec action to verify artifacts

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -52,3 +52,16 @@ jobs:
         CC: ${{ matrix.cc }}
       run: |
         /bin/sh -eux .actions/build-linux-${CC%-*}
+
+    - uses: nevun/action-checksec@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_COMMENT_URL: ${{ github.event.pull_request.comments_url }}
+      with:
+        executables: |
+          "/usr/local/bin/fido2-cred"
+          "/usr/local/bin/fido2-assert"
+          "/usr/local/bin/fido2-token"
+        libraries: |
+          "/usr/local/lib/libfido2.so"
+        verbose: "off"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,3 +11,20 @@ jobs:
     - uses: actions/checkout@v1
     - name: build
       run: .\windows\build.ps1
+
+    - uses: nevun/action-checksec@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_COMMENT_URL: ${{ github.event.pull_request.comments_url }}
+      with:
+        executables: |
+          "output/64/bin/fido2-cred.exe"
+          "output/64/bin/fido2-assert.exe"
+          "output/64/bin/fido2-token.exe"
+          "output/32/bin/fido2-cred.exe"
+          "output/32/bin/fido2-assert.exe"
+          "output/32/bin/fido2-token.exe"
+        libraries: |
+          "output/64/lib/fido2.dll"
+          "output/32/lib/fido2.dll"
+        verbose: "off"


### PR DESCRIPTION
Currently it uses checksec.sh and winchecksec (see LICENCE)
to run checks on linux and windows.

Right now it assumes that if running on Windows it should
use winchecksec and if on linux, use checksec.sh.

No support for macos since none of the used tools do.